### PR TITLE
feat: convert `main.tex` into responsive web page with Engrafo

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,36 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    container: arxivvanity/engrafo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Render document
+        run: engrafo main.tex output/
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'output/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR adds the GitHub workflow that renders static web assets generated from `main.tex` with Engrafo[^1] and deploys them to GitHub Pages.
If you want to know how this works, check out [my folk repo](https://yudukikun5120.github.io/yukie-gunron/).

[^1]: https://github.com/arxiv-vanity/engrafo